### PR TITLE
Add fairness upload integration

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI, UploadFile, File, Form
+from fastapi.middleware.cors import CORSMiddleware
+import pandas as pd
+import io
+from main import perform_fairness_check
+
+app = FastAPI()
+app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+
+@app.post("/fairness-check")
+async def fairness_check(
+    file: UploadFile = File(...),
+    label_col: str = Form("label"),
+    protected_attr: str = Form("group"),
+    tool: str = Form("fairlearn"),
+):
+    content = await file.read()
+    filename = file.filename.lower()
+    if filename.endswith((".xlsx", ".xls")):
+        df = pd.read_excel(io.BytesIO(content))
+    else:
+        df = pd.read_csv(io.BytesIO(content))
+    result = perform_fairness_check(df, label_col=label_col, protected_attr=protected_attr, fairness_tool=tool)
+    return result

--- a/backend/main.py
+++ b/backend/main.py
@@ -85,6 +85,45 @@ def run_with_deepchecks(df, protected_attr):
     result.save_as_html("deepchecks_report.html")
     print("✅ Deepchecks bias report saved to deepchecks_report.html")
 
+def perform_fairness_check(df, label_col, protected_attr, fairness_tool="fairlearn", config=None):
+    """Run a fairness check on ``df`` using the selected tool."""
+    if fairness_tool == "giskard":
+        import giskard
+        dataset = giskard.Dataset(
+            df,
+            target=label_col,
+            column_types={protected_attr: "category"}
+        )
+        model = giskard.Model(
+            model=lambda d: d[label_col],
+            model_type="classification",
+            name="Identity Model",
+            feature_names=df.columns.tolist()
+        )
+        report = giskard.scan(model, dataset)
+        report_path = "scan_report.html"
+        report.to_html(report_path)
+        return {"report_path": report_path}
+    elif fairness_tool == "fairlearn":
+        from fairlearn.metrics import MetricFrame, selection_rate, demographic_parity_difference
+        if label_col not in df.columns or protected_attr not in df.columns:
+            raise ValueError("Required columns not found in dataset")
+        df[label_col] = df[label_col].astype(int)
+        metric_frame = MetricFrame(
+            metrics=selection_rate,
+            y_pred=df[label_col],
+            sensitive_features=df[protected_attr]
+        )
+        disparity = demographic_parity_difference(
+            df[label_col], sensitive_features=df[protected_attr]
+        )
+        return {
+            "selection_rate_per_group": metric_frame.by_group.to_dict(),
+            "statistical_parity_gap": disparity
+        }
+    else:
+        raise ValueError(f"Unknown fairness tool: {fairness_tool}")
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", required=True, help="Path to llm_config.yaml")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,4 +4,4 @@ pandas
 boto3
 scikit-learn
 giskard
-pandas
+fairlearn

--- a/backend/venv/pyvenv.cfg
+++ b/backend/venv/pyvenv.cfg
@@ -1,3 +1,0 @@
-home = C:\Users\tejas\AppData\Local\Programs\Python\Python310
-include-system-site-packages = false
-version = 3.10.11

--- a/frontend/app/components/bias-metrics.tsx
+++ b/frontend/app/components/bias-metrics.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -32,6 +32,7 @@ import {
   Users,
   Target,
 } from "lucide-react"
+import { getFairnessResult } from "@/lib/process-dataset"
 
 // Enhanced mock data with more realistic values
 const demographicParityData = [
@@ -61,6 +62,11 @@ const overallScoreData = [{ name: "Fairness Score", value: 76, fill: "#F59E0B" }
 
 export function BiasMetrics() {
   const [loading, setLoading] = useState(false)
+  const [fairness, setFairness] = useState<any | null>(null)
+
+  useEffect(() => {
+    setFairness(getFairnessResult())
+  }, [])
 
   const handleRefresh = () => {
     setLoading(true)
@@ -125,6 +131,17 @@ export function BiasMetrics() {
           </Button>
         </div>
       </div>
+
+      {fairness && (
+        <Card className="border-0 bg-gradient-to-br from-emerald-50 to-teal-50 shadow-lg">
+          <CardContent className="p-6">
+            <h4 className="text-lg font-bold text-gray-800 mb-2">Fairness Results</h4>
+            <pre className="text-sm text-gray-700 whitespace-pre-wrap">
+              {JSON.stringify(fairness, null, 2)}
+            </pre>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Key Metrics Overview */}
       <div className="grid gap-6 md:grid-cols-4">

--- a/frontend/app/components/upload-dataset.tsx
+++ b/frontend/app/components/upload-dataset.tsx
@@ -6,7 +6,11 @@ import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
 import { Upload, FileSpreadsheet, AlertCircle, Sparkles, Zap, Target, FileText, CheckCircle } from "lucide-react"
-import { processDataset, setProcessedDataset } from "@/lib/process-dataset"
+import {
+  processDataset,
+  setProcessedDataset,
+  uploadDatasetToBackend,
+} from "@/lib/process-dataset"
 
 interface UploadDatasetProps {
   onDataProcessed: () => void
@@ -86,6 +90,13 @@ export function UploadDataset({ onDataProcessed }: UploadDatasetProps) {
       const result = await processDataset(file)
       setProcessedDataset(result) // Store globally
       setProcessedDataState(result)
+
+      // Send raw file to backend for fairness analysis
+      try {
+        await uploadDatasetToBackend(file)
+      } catch (e) {
+        console.error("Backend upload failed", e)
+      }
 
       setProgress(100)
       clearInterval(interval)

--- a/frontend/components/upload-dataset.tsx
+++ b/frontend/components/upload-dataset.tsx
@@ -6,7 +6,11 @@ import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
 import { Upload, FileSpreadsheet, AlertCircle, Sparkles, Zap, Target, FileText, CheckCircle } from "lucide-react"
-import { processDataset, setProcessedDataset } from "@/lib/process-dataset"
+import {
+  processDataset,
+  setProcessedDataset,
+  uploadDatasetToBackend,
+} from "@/lib/process-dataset"
 
 interface UploadDatasetProps {
   onDataProcessed: () => void
@@ -86,6 +90,13 @@ export function UploadDataset({ onDataProcessed }: UploadDatasetProps) {
       const result = await processDataset(file)
       setProcessedDataset(result) // Store globally
       setProcessedDataState(result)
+
+      // Send raw file to backend for fairness analysis
+      try {
+        await uploadDatasetToBackend(file)
+      } catch (e) {
+        console.error("Backend upload failed", e)
+      }
 
       setProgress(100)
       clearInterval(interval)

--- a/frontend/lib/process-dataset.ts
+++ b/frontend/lib/process-dataset.ts
@@ -212,3 +212,28 @@ export function setProcessedDataset(data: ProcessedDataset) {
 export function getProcessedDataset(): ProcessedDataset | null {
   return processedDatasetCache
 }
+
+// Store fairness results from the backend
+let fairnessResultCache: any = null
+
+export async function uploadDatasetToBackend(file: File) {
+  const formData = new FormData()
+  formData.append("file", file)
+
+  const res = await fetch("http://localhost:8000/fairness-check", {
+    method: "POST",
+    body: formData,
+  })
+
+  if (!res.ok) {
+    throw new Error("Failed to upload dataset to backend")
+  }
+
+  const data = await res.json()
+  fairnessResultCache = data
+  return data
+}
+
+export function getFairnessResult() {
+  return fairnessResultCache
+}


### PR DESCRIPTION
## Summary
- accept dataset file via `/fairness-check` FastAPI endpoint
- send uploaded dataset from Next.js to backend for analysis
- display fairness results on metrics page
- cleanup requirements and repository

## Testing
- `python3 -m py_compile backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6853f59671608323836d149337f62cdd