### PR TITLE
Use env variable for API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,14 @@ This project includes:
 │   └── requirements.txt
 ├── setup.sh          # Dev environment setup script
 └── README.md
+```
+
+## 🌐 Environment Variables
+
+Specify the backend endpoint for the frontend using `NEXT_PUBLIC_API_URL` in `frontend/.env.local`:
+
+```bash
+NEXT_PUBLIC_API_URL=http://localhost:8000
+```
+
+This value is read by the browser when uploading datasets.

--- a/frontend/lib/process-dataset.ts
+++ b/frontend/lib/process-dataset.ts
@@ -219,7 +219,10 @@ export async function uploadDatasetToBackend(file: File) {
   const formData = new FormData()
   formData.append("file", file)
 
-  const res = await fetch("http://localhost:8000/fairness-check", {
+  const backendUrl =
+    process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"
+
+  const res = await fetch(`${backendUrl}/fairness-check`, {
     method: "POST",
     body: formData,
   })


### PR DESCRIPTION
## Summary
- fetch the API URL from `NEXT_PUBLIC_API_URL`
- document the variable in the README

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854359ffd8c8323934cd1ebe491d864